### PR TITLE
Remove frozen requirement for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	cargo build --release --frozen
+	cargo build --release
 
 install:
 	cp target/release/tenki /usr/local/bin/


### PR DESCRIPTION
New users following the installation instructions can't install unless they already have all the required dependencies in their local cache.

An alternative would be to include an instruction to explicitly run `cargo fetch` to download them first.