### PR TITLE
feat: add wind mode control

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ paru -S tenki
 Usage: tenki [OPTIONS]
 
 Options:
-      --mode <MODE>    [default: rain] [possible values: rain, snow]
-      --fps <FPS>      [default: 30] 1-60
-      --color <COLOR>  [default: white] [red, green, blue, yellow, cyan, magenta, white, black]
-  -l, --level <LEVEL>  effect level, The lower, the stronger [4-1000] [default: 50]
+      --mode <MODE>    [default: rain] [rain, snow]
+      --fps <FPS>      [default: 30] [1-60]
+      --color <COLOR>  Timer color [default: white] [red, green, blue, yellow, cyan, magenta, white, black]
+      --wind <WIND>    Decide on the direction of the rain/snow [defualt: random] [random, disable, only-right, only-left]
+  -l, --level <LEVEL>  Effect level, The lower, the stronger [default: 50] [4-1000]
   -h, --help           Print help
   -V, --version        Print version
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use clap::Parser;
 use clap_num::number_range;
 use ratatui::style::Color;
-use crate::app::Mode;
+use crate::app::{Mode, WindMode};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -21,6 +21,10 @@ pub struct Args {
     /// color of the effect. [red, green, blue, yellow, cyan, magenta, white, black]
     #[arg(long, value_parser = Color::from_str, default_value = "white")]
     pub timer_color: Color,
+
+    /// wind mode. [random, disable, only-right, only-left]
+    #[arg(long, value_parser = WindMode::from_str, default_value = "random")]
+    pub wind: WindMode,
 }
 
 fn fps_range(s: &str) -> Result<u8, String> {


### PR DESCRIPTION
add `--wind` to cli flag, default is `random` acceptable `random`, `disable`, `only-right`, `only-left` values.

this flag enabling wind mode to be controlled.